### PR TITLE
fixed a bug with a newer git version

### DIFF
--- a/gitric/api.py
+++ b/gitric/api.py
@@ -31,10 +31,11 @@ def git_seed(repo_path, commit=None, ignore_untracked_files=False):
     run('git init %s' % repo_path)
 
     # finis execution if remote git it's already on commit.
-    with cd(repo_path):
-        if run('git rev-parse HEAD') == commit:
-            puts('Remote already on commit %s' % commit)
-            return
+    with settings(warn_only=True):
+        with cd(repo_path):
+            if run('git rev-parse HEAD') == commit:
+                puts('Remote already on commit %s' % commit)
+                return
 
     # silence git complaints about pushes coming in on the current branch
     # the pushes only seed the immutable object store and do not modify the


### PR DESCRIPTION
git rev-parse HEAD fails if there is no commit yet (first deploy)
